### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ template with modern Python workflows
 
 Inspired by [copier-uv](https://github.com/pawamoy/copier-uv),
 [cookiecutter-data-science](https://github.com/drivendataorg/cookiecutter-data-science),
-and [BestieTemplates.jl](https://github.com/abelsiqueira/BestieTemplate.jl).
+and [BestieTemplates.jl](https://github.com/JuliaBesties/BestieTemplate.jl).
 
 ## Packaging Guide
 


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
